### PR TITLE
Fix axios and brace-expansion advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@vue/runtime-dom": "^3.3.4",
         "animated-scroll-to": "^2.2.0",
         "aos": "^2.3.4",
-        "axios": "^1.16.1",
+        "axios": "^1.18.1",
         "lottie-web": "^5.12.2",
         "normalize.css": "^8.0.1",
         "vue": "^3.3.4",
@@ -1317,9 +1317,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -1343,9 +1343,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@vue/runtime-dom": "^3.3.4",
     "animated-scroll-to": "^2.2.0",
     "aos": "^2.3.4",
-    "axios": "^1.16.1",
+    "axios": "^1.18.1",
     "lottie-web": "^5.12.2",
     "normalize.css": "^8.0.1",
     "vue": "^3.3.4",


### PR DESCRIPTION
## Summary

Non-breaking `npm audit fix` plus an axios floor bump:

| Package | Change | Notes |
|---------|--------|-------|
| **axios** | `^1.16.1` → `^1.18.1` | Resolves 10 advisories: formDataToJSON DoS ([GHSA-42h9-826w-cgv3](https://github.com/advisories/GHSA-42h9-826w-cgv3)), prototype-pollution auth injection ([GHSA-xj6q-8x83-jv6g](https://github.com/advisories/GHSA-xj6q-8x83-jv6g)), `maxBodyLength` bypasses, NO_PROXY bypass, and more |
| **brace-expansion** | `1.1.13` → `1.1.16` | [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) — DoS via exponential `{}` expansion (transitive) |

`package.json` axios floor raised so the fix survives a fresh resolve.

## Verification

- `npm audit` → **0 vulnerabilities**
- `npm run build` → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)