### PR TITLE
Fix js-yaml advisory (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2291,9 +2291,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Lockfile-only, non-breaking `npm audit fix`:

| Package | Change | Advisory |
|---------|--------|----------|
| **js-yaml** | `4.3.0` → `4.3.1` | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — quadratic CPU consumption in `!!omap` resolution (CVE-2026-59870). Transitive via `eslint`. |

No `package.json` changes — transitive, resolved in `package-lock.json`.

## Verification

- `npm audit` → **0 vulnerabilities**
- `npm run build` → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)